### PR TITLE
Calculate checksum using the same method as TASM

### DIFF
--- a/src/uz80as.c
+++ b/src/uz80as.c
@@ -767,7 +767,7 @@ static int checksum(int a, int b)
 
 	n = 0;
 	while (a < b)
-		n += s_mem[a++];
+		n ^= s_mem[a++];
 
 	return n;
 }


### PR DESCRIPTION
Rather than what is suggested in the documentation, the CHK checksum in TASM is actually calculated as the bitwise XOR of all bytes starting at the starting_addr up to but not including the address of the CHK directive.

For example (from http://z80-heaven.wikidot.com/directives:chk): 
```
0001   0000             	.org	0
0002   0000 01          _label: .byte	1
0003   0001 04          	.byte	4
0004   0002 36          	.byte	54
0005   0003 33          	.chk	_label ; Has a value of 59 with Brass, 51 in TASM.
0006   0004             	.end
```